### PR TITLE
:arrow_up: Upgrades Whisparr to 2.0.0.987

### DIFF
--- a/whisparr/Dockerfile
+++ b/whisparr/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BUILD_FROM}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
-ARG WHISPARR_VERSION="2.0.0.548"
+ARG WHISPARR_VERSION="2.0.0.987"
 ARG BUILD_ARCH=amd64
 ARG BUILD_VERSION=dev
 ENV XDG_CONFIG_HOME="/config/xdg"


### PR DESCRIPTION
# Proposed Changes

Upgrades Whisparr to the latest greatest available version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the default Whisparr version included in the Docker image to 2.0.0.987.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->